### PR TITLE
[WIP]use parameter to define keyword

### DIFF
--- a/MyTypeScriptLog.txt
+++ b/MyTypeScriptLog.txt
@@ -1,0 +1,6 @@
+Info 0    [18:48:52.178] Starting TS Server
+Info 1    [18:48:52.178] Version: 4.0.2
+Info 2    [18:48:52.178] Arguments: /Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper (Renderer).app/Contents/MacOS/Code Helper (Renderer) /Applications/Visual Studio Code.app/Contents/Resources/app/extensions/node_modules/typescript/lib/tsserver.js --serverMode partialSemantic --useInferredProjectPerProjectRoot --disableAutomaticTypingAcquisition --cancellationPipeName /var/folders/m3/8ypx7nx508dg_2bbtz3z4pmr0000gn/T/vscode-typescript501/33858811ecd0859e7fd5/tscancellation-49038ceb7704af38b68e.tmp* --globalPlugins typescript-vscode-sh-plugin,typescript-lit-html-plugin,typescript-tailwindcssinjs-plugin --pluginProbeLocations /Applications/Visual Studio Code.app/Contents/Resources/app/extensions/typescript-language-features,/Users/williamcastandet/.vscode/extensions/bierner.lit-html-1.11.1,/Users/williamcastandet/Documents/vscode-tailwindcssinjs --locale en --noGetErrOnBackgroundUpdate --validateDefaultNpmLocation
+Info 3    [18:48:52.178] Platform: darwin NodeVersion: 12 CaseSensitive: false
+Info 4    [18:48:52.178] ServerMode: 1 syntaxOnly: false hasUnknownServerMode: undefined
+Info 5    [18:48:52.184] Exiting...

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
           "default": true,
           "description": "use Trigger character completion proxy."
         },
+        "tailwindcssinjs.templateStringKeyword": {
+          "type": "string",
+          "default": "tw",
+          "description": "define the keyword to trigger the suggestion."
+        },
         "tailwindcssinjs.ignoreErrors": {
           "type": [
             "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ const disposables: vscode.Disposable[] = [];
 export async function activate(context: vscode.ExtensionContext) {
   const configuration = vscode.workspace.getConfiguration('tailwindcssinjs')
   const ignoreErrors = configuration.get("ignoreErrors")
+  const templateStringKeyword = configuration.get("templateStringKeyword") as string
   const typescriptLanguageFeaturesExtension = vscode.extensions.getExtension(
     TYPESCRIPT_EXTENSION_ID
   );
@@ -45,6 +46,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   typescriptLanguageServerPluginApi.configurePlugin(PLUGIN_ID, {
     config: tailwindConfigfiles[0]?.path,
+    templateStringKeyword,
     ignoreErrors
   });
 
@@ -57,6 +59,7 @@ export async function activate(context: vscode.ExtensionContext) {
       console.log(`Config ${action}`, e.path);
       typescriptLanguageServerPluginApi.configurePlugin(PLUGIN_ID, {
         config: e.path,
+        templateStringKeyword,
         ignoreErrors
       });
     };
@@ -68,6 +71,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   //TODO: get tailwind config separator
   if (configuration.get("useCompletionItemProviderTriggerProxy")) {
+    const tailwindcssinjsCompletionProvider = getTailwindcssinjsCompletionProvider(templateStringKeyword)
     disposables.push(
       vscode.languages.registerCompletionItemProvider(
         SELECTORS,
@@ -86,7 +90,7 @@ export function deactivate(): Thenable<void> | void | undefined {
   }
 }
 
-const tailwindcssinjsCompletionProvider = {
+const getTailwindcssinjsCompletionProvider = (templateStringKeyword:string): any => ({
   async provideCompletionItems(
     document: vscode.TextDocument,
     position: vscode.Position,
@@ -97,7 +101,8 @@ const tailwindcssinjsCompletionProvider = {
     //check if triggered by trigger character
     if (context.triggerKind === 1) {
       //get tailwindcssinjs template tags in file
-      const tags = getTailwindcssinjsTagsFromDocument(document);
+      const tt = templateStringKeyword;
+      const tags = getTailwindcssinjsTagsFromDocument(document, templateStringKeyword);
       //get tag if current position is inside a tailwindcssinjs tag
       const tag = getTailwindcssinjsTagFromPosition(position, tags);
 
@@ -110,4 +115,4 @@ const tailwindcssinjsCompletionProvider = {
       }
     }
   },
-};
+});

--- a/src/getTailwindcssinjsTag.ts
+++ b/src/getTailwindcssinjsTag.ts
@@ -10,14 +10,16 @@ export interface Tags {
 }
 
 export function getTailwindcssinjsTagsFromDocument(
-  textDocument: vscode.TextDocument
+  textDocument: vscode.TextDocument,
+  templateStringKeyword: string
 ): Tags[] {
   const text = textDocument.getText();
-  const patternTag = /(tw`)([^`]*)+`/g;
+  const strPatternTag = `(${templateStringKeyword}\`)([^\`]*)+\``
+  const patternTag = new RegExp(strPatternTag, 'g');
   const tags: Tags[] = [];
   let tag: RegExpExecArray | null;
   while ((tag = patternTag.exec(text))) {
-    const index = tag.index + "tw`".length;
+    const index = tag.index + `${templateStringKeyword}\``.length;
     const tagx = {
       text: tag[2],
       index,


### PR DESCRIPTION
it's not working right now, so maybe i can get help here.

what i did is add a parameter that default to `tw` so you can define the keyword to trigger the autocomplete.
linked to #4 

i used vscode debug and the regexp is working, the values are `ow` but the autocomplete still only appears on `tw` and nothing on `ow` even if the regexp is with `ow` and all that.

Maybe someone know what's happening, i'm not used to vscode.

the repl that test the RegExp: https://repl.it/repls/MidnightbluePopularMention